### PR TITLE
fix: jumping cursor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ class RichTextInput extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.input.value !== this.props.input.value) {
+        if (nextProps.input.value !== editor.innerHTML) {
             this.quill.pasteHTML(nextProps.input.value);
         }
     }


### PR DESCRIPTION
In current version, while pasting or typing the cursor is jumping to the beginning of the input box. That's because each change of editor content causes the same content to be pasted back to the editor.
While pasting only content that do not match current editor inner html allows to keep cursor in its place while typing and also to follow updates done via redux form.